### PR TITLE
Define NO_STRICT for Windows to avoid STRICT name collision

### DIFF
--- a/cmake/platform/windows.cmake
+++ b/cmake/platform/windows.cmake
@@ -59,6 +59,7 @@ endif()
 if(WIN32)
   add_definitions(-DNOMINMAX)   # not to define min/max macros
   add_definitions(-DNO_STRICT)  # not to define STRICT macros (minwindef.h or boost\winapi\basic_types.hpp)
+  add_definitions(-DQ_NOWINSTRICT)  # not to define STRICT macros (qtgui\qwindowdefs_win.h)
 endif()
 
 #

--- a/cmake/platform/windows.cmake
+++ b/cmake/platform/windows.cmake
@@ -55,9 +55,10 @@ if(BUILD_SHARED_LIBS)
   endif()
 endif()
 
-# For MSVC, add difinitions to exclude the definitions for common names macros that cause name collision
-if(MSVC)
+# For Windows, add difinitions to exclude the definitions for common names macros that cause name collision
+if(WIN32)
   add_definitions(-DNOMINMAX)   # not to define min/max macros
+  add_definitions(-DNO_STRICT)  # not to define STRICT macros (minwindef.h or boost\winapi\basic_types.hpp)
 endif()
 
 #


### PR DESCRIPTION
* Even after we remove Windows.h, I still see STRICT getting defined. It turned out boost does that too. So, here I define NO_STRICT to explicitly ask boost not to define STRICT to pollute the global namespace and define Q_NOWINSTRICT to keep the QT compile settings in sync. (And btw, the boost STRICT issue is created here: https://github.com/boostorg/winapi/issues/74)

* Change the condition from MSVC to WIN32 since it is not compiler specific, but a Windows platform issue.