### PR TITLE
Add more Windows global helper.

### DIFF
--- a/cmake/platform/windows.cmake
+++ b/cmake/platform/windows.cmake
@@ -60,6 +60,11 @@ if(WIN32)
   add_definitions(-DNOMINMAX)   # not to define min/max macros
   add_definitions(-DNO_STRICT)  # not to define STRICT macros (minwindef.h or boost\winapi\basic_types.hpp)
   add_definitions(-DQ_NOWINSTRICT)  # not to define STRICT macros (qtgui\qwindowdefs_win.h)
+  add_definitions(-D_USE_MATH_DEFINES)  # enable Math Constants https://docs.microsoft.com/en-us/cpp/c-runtime-library/math-constants
+endif()
+
+if(MSVC)
+  add_compile_options(/Zc:__cplusplus) # https://blogs.msdn.microsoft.com/vcblog/2018/04/09/msvc-now-correctly-reports-__cplusplus/
 endif()
 
 #


### PR DESCRIPTION
* Define _USE_MATH_DEFINES by default so whoever includes <math.h> can see _M_PI and other constant like posix build system.
* Enable /Zc:__cplusplus by default to enable many downstream modules to check C++ version in GCC way in MSVC. For examples, like this `#if __cplusplus >= 201103L`
