### PR TITLE
add  WIN32_LEAN_AND_MEAN

### DIFF
--- a/cmake/platform/windows.cmake
+++ b/cmake/platform/windows.cmake
@@ -57,6 +57,7 @@ endif()
 
 # For Windows, add difinitions to exclude the definitions for common names macros that cause name collision
 if(WIN32)
+  add_definitions(-DWIN32_LEAN_AND_MEAN) # keep minimum windows headers inclusion
   add_definitions(-DNOMINMAX)   # not to define min/max macros
   add_definitions(-DNO_STRICT)  # not to define STRICT macros (minwindef.h or boost\winapi\basic_types.hpp)
   add_definitions(-DQ_NOWINSTRICT)  # not to define STRICT macros (qtgui\qwindowdefs_win.h)


### PR DESCRIPTION
This is part of a fix for https://github.com/ms-iot/ROSOnWindows/issues/34

In current ROS code base, it still exists some modules (For example, OGRE 1.10.x or ros\io.h) exposing windows.h and causes namespace pollution. Here we add WIN32_LEAN_AND_MEAN to minimize the problem. Meanwhile we are still looking into reduce the scope for windows.h inclusion.