### PR TITLE
correct python macro in cmake files

### DIFF
--- a/cmake/catkin_download.cmake
+++ b/cmake/catkin_download.cmake
@@ -56,7 +56,7 @@ function(catkin_download target url)
   # this is because we want to check the md5 sum if it's given, and redownload
   # the target if the md5 sum does not match.
   add_custom_target(${target}
-    COMMAND ${PYTHON} ${catkin_EXTRAS_DIR}/test/download_checkmd5.py ${url} ${output} ${ARG_MD5} ${required}
+    COMMAND ${PYTHON_EXECUTABLE} ${catkin_EXTRAS_DIR}/test/download_checkmd5.py ${url} ${output} ${ARG_MD5} ${required}
     VERBATIM)
 
   if(ARG_EXCLUDE_FROM_ALL)


### PR DESCRIPTION
correct python macro (`${PYTHON_EXECUTABLE}`) in cmake files